### PR TITLE
feat: 함수 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/pink/backend/feature/function/controller/FuncController.java
+++ b/src/main/java/com/pink/backend/feature/function/controller/FuncController.java
@@ -3,25 +3,36 @@ package com.pink.backend.feature.function.controller;
 import com.pink.backend.feature.function.dto.FuncCreateReq;
 import com.pink.backend.feature.function.dto.FuncCreateRes;
 import com.pink.backend.feature.function.dto.FuncDeleteRes;
+import com.pink.backend.feature.function.dto.FuncListItemDto;
 import com.pink.backend.feature.function.dto.FuncUpdateCodeReq;
 import com.pink.backend.feature.function.dto.FuncUpdateCodeRes;
 import com.pink.backend.feature.function.service.FuncCreateService;
 import com.pink.backend.feature.function.service.FuncDeleteService;
+import com.pink.backend.feature.function.service.FuncListService;
 import com.pink.backend.feature.function.service.FuncUpdateService;
 import com.pink.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
+@Tag(name = "Function", description = "서버리스 함수 관리 API")
 @RestController
 @RequestMapping("/api/functions")
 @RequiredArgsConstructor
@@ -30,24 +41,39 @@ public class FuncController {
     private final FuncCreateService funcCreateService;
     private final FuncUpdateService funcUpdateService;
     private final FuncDeleteService funcDeleteService;
+    private final FuncListService funcListService;
 
+    @Operation(summary = "함수 생성", description = "새로운 서버리스 함수를 생성합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<FuncCreateRes>> createFunction(@RequestBody FuncCreateReq request) {
         FuncCreateRes response = funcCreateService.createFunction(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
     }
 
+    @Operation(summary = "함수 코드 수정", description = "기존 함수의 코드를 수정하고 새 버전을 생성합니다.")
     @PutMapping("/{functionId}/code")
     public ResponseEntity<ApiResponse<FuncUpdateCodeRes>> updateFunctionCode(
-            @PathVariable UUID functionId,
+            @Parameter(description = "함수 ID", required = true) @PathVariable UUID functionId,
             @RequestBody FuncUpdateCodeReq request) {
         FuncUpdateCodeRes response = funcUpdateService.updateFunctionCode(functionId, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "함수 삭제", description = "함수를 삭제합니다.")
     @DeleteMapping("/{functionId}")
-    public ResponseEntity<ApiResponse<FuncDeleteRes>> deleteFunction(@PathVariable UUID functionId) {
+    public ResponseEntity<ApiResponse<FuncDeleteRes>> deleteFunction(
+            @Parameter(description = "함수 ID", required = true) @PathVariable UUID functionId) {
         FuncDeleteRes response = funcDeleteService.deleteFunction(functionId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "함수 목록 조회", description = "함수 목록을 커서 기반 페이지네이션으로 조회합니다. 페이지 크기는 10으로 고정됩니다. 마지막 항목의 updatedAt 값을 다음\n"
+        + "요청의 cursor 파라미터로 사용하면 됩니다")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FuncListItemDto>>> getFunctionList(
+        @Parameter(description = "커서 (updatedAt 기준, 형식: yyyy-MM-dd'T'HH:mm:ss)", required = false)
+        @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime cursor) {
+        List<FuncListItemDto> response = funcListService.getFunctionList(cursor);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/pink/backend/feature/function/dao/FunctionRepository.java
+++ b/src/main/java/com/pink/backend/feature/function/dao/FunctionRepository.java
@@ -1,11 +1,22 @@
 package com.pink.backend.feature.function.dao;
 
 import com.pink.backend.feature.function.entity.Function;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface FunctionRepository extends JpaRepository<Function, UUID> {
+
+    @Query("SELECT f FROM Function f WHERE f.updatedAt < :cursor ORDER BY f.updatedAt DESC")
+    List<Function> findByCursorBefore(@Param("cursor") LocalDateTime cursor, Pageable pageable);
+
+    @Query("SELECT f FROM Function f ORDER BY f.updatedAt DESC")
+    List<Function> findAllOrderByUpdatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/pink/backend/feature/function/dto/FuncListItemDto.java
+++ b/src/main/java/com/pink/backend/feature/function/dto/FuncListItemDto.java
@@ -1,0 +1,35 @@
+package com.pink.backend.feature.function.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FuncListItemDto {
+
+    private UUID functionId;
+    private String name;
+    private String runtime;
+    private Integer latestVersion;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime updatedAt;
+
+    public static FuncListItemDto from(com.pink.backend.feature.function.entity.Function function) {
+        return FuncListItemDto.builder()
+                .functionId(function.getId())
+                .name(function.getName())
+                .runtime(function.getRuntime())
+                .latestVersion(function.getLatestVersion())
+                .updatedAt(function.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/pink/backend/feature/function/service/FuncListService.java
+++ b/src/main/java/com/pink/backend/feature/function/service/FuncListService.java
@@ -1,0 +1,39 @@
+package com.pink.backend.feature.function.service;
+
+import com.pink.backend.feature.function.dao.FunctionRepository;
+import com.pink.backend.feature.function.dto.FuncListItemDto;
+import com.pink.backend.feature.function.entity.Function;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FuncListService {
+
+    private static final int PAGE_SIZE = 10;
+
+    private final FunctionRepository functionRepository;
+
+    public List<FuncListItemDto> getFunctionList(LocalDateTime cursor) {
+        Pageable pageable = PageRequest.of(0, PAGE_SIZE);
+        List<Function> functions;
+
+        if (cursor == null) {
+            functions = functionRepository.findAllOrderByUpdatedAtDesc(pageable);
+        } else {
+            functions = functionRepository.findByCursorBefore(cursor, pageable);
+        }
+
+        return functions.stream()
+                .map(FuncListItemDto::from)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Related Issues
- close #13 

## 작업내용
[feat: 함수 목록 조회 API 구현](https://github.com/SOFTBANK-Hackaton-Final-Pink/pink-backend/commit/eae9cdc202a1c7d3a5a84b10fa0aaaee83e8b63b)
    - GET /api/functions 엔드포인트 추가
    - 커서 기반 페이지네이션 구현 (페이지 크기 10 고정, 다음 페이지는 마지막 항목의 updatedAt 값으로 요청)
    - updatedAt 기준 내림차순 정렬
    - FuncListItemDto 및 FuncListService 추가
    - FunctionRepository에 커서 기반 조회 쿼리 추가
    - Swagger 문서화 어노테이션 추가