### PR TITLE
fix: Dockerfile에서 test 폴더 제외 및 .dockerignore 파일 작성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Test files
+src/test/
+**/test/
+**/*Test.java
+**/*Tests.java
+
+# Build outputs
+.gradle/
+build/
+!build/libs/*.jar
+
+# IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+*.md
+HELP.md
+
+# Misc
+.github/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY gradlew.bat .
 COPY build.gradle.kts .
 COPY settings.gradle.kts .
 
-COPY src src
+COPY src/main src/main
 
 RUN chmod +x ./gradlew && ./gradlew build -x test --no-daemon
 


### PR DESCRIPTION
## Related Issues
- close #21 

[fix: Dockerfile에서 test 폴더 제외 및 .dockerignore 파일작성](https://github.com/SOFTBANK-Hackaton-Final-Pink/pink-backend/commit/2dd95738024afd7b8fa0e73a5654b3174074f67b)

## 작업내용
- [x] test 폴더 제외
- [x] .dockerignore 파일 작성
